### PR TITLE
Add nullptr handling for ToFmtArg_String, ToCString, and To_bstr_t

### DIFF
--- a/vlr-util.test/test.util.convert.StringConversion.cpp
+++ b/vlr-util.test/test.util.convert.StringConversion.cpp
@@ -64,6 +64,112 @@ TEST(StringConversion, ToStdStringW_Nullptr_And_Pointer)
 	EXPECT_EQ(s5, ToStdStringW(std::string_view{ pcStr }));
 }
 
+TEST(StringConversion, ToFmtArg_StringA_Nullptr_And_Pointer)
+{
+	// nullptr_t overload
+	auto s1 = ToFmtArg_StringA(nullptr);
+	EXPECT_EQ(std::string_view{ s1 }.length(), 0u);
+
+	// const char* null (same-width)
+	const char* psaNull = nullptr;
+	auto s2 = ToFmtArg_StringA(psaNull);
+	EXPECT_EQ(std::string_view{ s2 }.length(), 0u);
+
+	// const wchar_t* null (cross-width)
+	const wchar_t* pswNull = nullptr;
+	auto s3 = ToFmtArg_StringA(pswNull);
+	EXPECT_EQ(std::string{ s3 }.length(), 0u);
+
+	// const char* non-null passes through as a valid view
+	const char* pStr = "abc";
+	auto s4 = ToFmtArg_StringA(pStr);
+	EXPECT_STREQ(std::string{ s4 }.c_str(), "abc");
+
+	// Also verify usage in fmt::format does not crash
+	auto sFormatted = fmt::format("[{}]", ToFmtArg_StringA(psaNull));
+	EXPECT_EQ(sFormatted, "[]");
+}
+
+TEST(StringConversion, ToFmtArg_StringW_Nullptr_And_Pointer)
+{
+	// nullptr_t overload
+	auto s1 = ToFmtArg_StringW(nullptr);
+	EXPECT_EQ(std::wstring_view{ s1 }.length(), 0u);
+
+	// const wchar_t* null (same-width)
+	const wchar_t* pswNull = nullptr;
+	auto s2 = ToFmtArg_StringW(pswNull);
+	EXPECT_EQ(std::wstring_view{ s2 }.length(), 0u);
+
+	// const char* null (cross-width)
+	const char* psaNull = nullptr;
+	auto s3 = ToFmtArg_StringW(psaNull);
+	EXPECT_EQ(std::wstring{ s3 }.length(), 0u);
+
+	// const wchar_t* non-null passes through
+	const wchar_t* pStr = L"abc";
+	auto s4 = ToFmtArg_StringW(pStr);
+	EXPECT_STREQ(std::wstring{ s4 }.c_str(), L"abc");
+
+	auto sFormatted = fmt::format(L"[{}]", ToFmtArg_StringW(pswNull));
+	EXPECT_EQ(sFormatted, L"[]");
+}
+
+TEST(StringConversion, ToCStringA_Nullptr_And_Pointer)
+{
+	auto s1 = ToCStringA(nullptr);
+	EXPECT_EQ(s1.GetLength(), 0);
+
+	const char* psaNull = nullptr;
+	auto s2 = ToCStringA(psaNull);
+	EXPECT_EQ(s2.GetLength(), 0);
+
+	const wchar_t* pswNull = nullptr;
+	auto s3 = ToCStringA(pswNull);
+	EXPECT_EQ(s3.GetLength(), 0);
+
+	const char* pStr = "abc";
+	auto s4 = ToCStringA(pStr);
+	EXPECT_STREQ(s4, "abc");
+}
+
+TEST(StringConversion, ToCStringW_Nullptr_And_Pointer)
+{
+	auto s1 = ToCStringW(nullptr);
+	EXPECT_EQ(s1.GetLength(), 0);
+
+	const wchar_t* pswNull = nullptr;
+	auto s2 = ToCStringW(pswNull);
+	EXPECT_EQ(s2.GetLength(), 0);
+
+	const char* psaNull = nullptr;
+	auto s3 = ToCStringW(psaNull);
+	EXPECT_EQ(s3.GetLength(), 0);
+
+	const wchar_t* pStr = L"abc";
+	auto s4 = ToCStringW(pStr);
+	EXPECT_STREQ(s4, L"abc");
+}
+
+TEST(StringConversion, To_bstr_t_Nullptr_And_Pointer)
+{
+	auto s1 = Convert::To_bstr_t(nullptr);
+	EXPECT_EQ(s1.length(), 0u);
+
+	const wchar_t* pswNull = nullptr;
+	auto s2 = Convert::To_bstr_t(pswNull);
+	EXPECT_EQ(s2.length(), 0u);
+
+	const char* psaNull = nullptr;
+	auto s3 = Convert::To_bstr_t(psaNull);
+	EXPECT_EQ(s3.length(), 0u);
+
+	const wchar_t* pStr = L"abc";
+	auto s4 = Convert::To_bstr_t(pStr);
+	EXPECT_EQ(s4.length(), 3u);
+	EXPECT_STREQ(static_cast<const wchar_t*>(s4), L"abc");
+}
+
 TEST(StringConversion, ToStdStringA_OverloadResolution)
 {
 	// Should resolve to std::string_view overload

--- a/vlr-util/util.convert.StringConversion.h
+++ b/vlr-util/util.convert.StringConversion.h
@@ -324,6 +324,41 @@ inline decltype(auto) ToStdStringW_FromSystemDefaultASCII(const TString& tString
 
 #if VLR_CONFIG_INCLUDE_ATL_CString
 
+// Nullptr and pointer overloads for ToCStringA/W
+// Without these, passing a nullptr C-string would implicitly construct a
+// std::string_view from nullptr, invoking strlen(nullptr) and crashing.
+
+inline CStringA ToCStringA(std::nullptr_t, const StringConversionOptions& = {}) noexcept
+{
+	return CStringA{};
+}
+inline CStringW ToCStringW(std::nullptr_t, const StringConversionOptions& = {}) noexcept
+{
+	return CStringW{};
+}
+
+inline CStringA ToCStringA(const char* s, const StringConversionOptions& = {})
+{
+	if (!s) { return CStringA{}; }
+	return CStringA{ s };
+}
+inline CStringA ToCStringA(const wchar_t* s, const StringConversionOptions& oConversionOptions = {})
+{
+	if (!s) { return CStringA{}; }
+	return CStringConversion{}.Inline_UTF16_to_MultiByte_CString(std::wstring_view{ s }, oConversionOptions);
+}
+
+inline CStringW ToCStringW(const wchar_t* s, const StringConversionOptions& = {})
+{
+	if (!s) { return CStringW{}; }
+	return CStringW{ s };
+}
+inline CStringW ToCStringW(const char* s, const StringConversionOptions& oConversionOptions = {})
+{
+	if (!s) { return CStringW{}; }
+	return CStringConversion{}.Inline_MultiByte_to_UTF16_CString(std::string_view{ s }, oConversionOptions);
+}
+
 inline auto ToCStringA(std::string_view svValue, const StringConversionOptions& /*oConversionOptions*/ = {})
 {
 	return CStringA{ svValue.data(), range_checked_cast<int>(svValue.length()) };
@@ -473,6 +508,25 @@ inline auto To_bstr_t_choice(const TString& tString, const StringConversionOptio
 
 } // namespace detail
 
+// Nullptr and pointer overloads for To_bstr_t
+// Without these, the choice<1> template matches wstring_view-convertible types
+// (including const wchar_t*), and a nullptr triggers wcslen(nullptr).
+
+inline _bstr_t To_bstr_t(std::nullptr_t, const StringConversionOptions& = {}) noexcept
+{
+	return _bstr_t{};
+}
+inline _bstr_t To_bstr_t(const wchar_t* s, const StringConversionOptions& = {})
+{
+	if (!s) { return _bstr_t{}; }
+	return _bstr_t{ s };
+}
+inline _bstr_t To_bstr_t(const char* s, const StringConversionOptions& = {})
+{
+	if (!s) { return _bstr_t{}; }
+	return _bstr_t{ s };
+}
+
 template <typename TString>
 inline auto To_bstr_t(const TString& tString, const StringConversionOptions& oConversionOptions = {})
 {
@@ -551,6 +605,45 @@ constexpr decltype(auto) ToFmtArg_StringW_choice(TString&& tString, const String
 }
 
 } // namespace detail
+
+// Nullptr and pointer overloads for ToFmtArg_StringA/W
+// These take precedence over the template forms below, so that a nullptr
+// C-string argument returns an empty view instead of triggering UB inside
+// std::string_view/std::wstring_view construction (strlen/wcslen on nullptr).
+
+constexpr std::string_view ToFmtArg_StringA(std::nullptr_t, const StringConversionOptions& = {}) noexcept
+{
+	return std::string_view{};
+}
+constexpr std::wstring_view ToFmtArg_StringW(std::nullptr_t, const StringConversionOptions& = {}) noexcept
+{
+	return std::wstring_view{};
+}
+
+constexpr std::string_view ToFmtArg_StringA(const char* s, const StringConversionOptions& = {}) noexcept
+{
+	return s ? std::string_view{ s } : std::string_view{};
+}
+constexpr std::wstring_view ToFmtArg_StringW(const wchar_t* s, const StringConversionOptions& = {}) noexcept
+{
+	return s ? std::wstring_view{ s } : std::wstring_view{};
+}
+
+// Cross-width pointer overloads: the fallback (ToStdString[A/W]) already
+// handles nullptr correctly, but we route through it explicitly so the
+// choice-based dispatch cannot accidentally match a string_view overload
+// for a nullptr input in the future.
+
+inline std::string ToFmtArg_StringA(const wchar_t* s, const StringConversionOptions& oConversionOptions = {})
+{
+	if (!s) { return std::string{}; }
+	return ToStdStringA(std::wstring_view{ s }, oConversionOptions);
+}
+inline std::wstring ToFmtArg_StringW(const char* s, const StringConversionOptions& oConversionOptions = {})
+{
+	if (!s) { return std::wstring{}; }
+	return ToStdStringW(std::string_view{ s }, oConversionOptions);
+}
 
 template <typename TString>
 constexpr decltype(auto) ToFmtArg_StringA(TString&& tString, const StringConversionOptions& oConversionOptions = {})


### PR DESCRIPTION
Extends the existing nullptr-safety pattern used by ToStdStringA/W to the remaining public string-conversion entry points. Without these, passing a nullptr C-string (const char* / const wchar_t*) matched the choice<1> template overload and implicitly constructed a std::string_view or std::wstring_view from nullptr, invoking strlen/wcslen on nullptr and crashing at runtime.

Adds non-template overloads for nullptr_t and the same-width / cross-width pointer types to:
  - ToFmtArg_StringA / ToFmtArg_StringW  (root cause of observed crashes)
  - ToCStringA / ToCStringW
  - To_bstr_t

Adds unit tests that would crash without the fix.